### PR TITLE
Fixed Bukkit#clearRecipes()

### DIFF
--- a/5-1.md
+++ b/5-1.md
@@ -125,7 +125,7 @@ Bukkit 这里还有一个很坑的地方，服务器要关闭时要**调用 `cle
 ```java
 @Override
 public void onDisable() {
-    Bukkit.clearRecipes();
+    Bukkit.resetRecipes();
 }
 ```
 


### PR DESCRIPTION
我修改的地方不应是 `Bukkit#clearRecipes()`，而应是 `Bukkit#resetRecipes()`  
前者会移除服务器所有合成配方（包括原版的），而后者是对服务器中被插件修改过的配方的重置。